### PR TITLE
Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ local.properties
 res/values/bugsense.xml
 
 # Ignore the lib files
-lib/
+libs/
 
 # Ignore Mac hidden dir file
 *.DS_Store


### PR DESCRIPTION
Previous version of .gitignore didn't ignore Android Studio (IntelliJ) project settings files, or /lib folder.

Also added *.DS_Store to ignore any hidden Mac OS X directory files.

Changes make it much easier for contributions from developers with different environments.
