### PR TITLE
Issue 40 integrated browser refresh on rotate

### DIFF
--- a/src/com/airlocksoftware/hackernews/fragment/WebFragment.java
+++ b/src/com/airlocksoftware/hackernews/fragment/WebFragment.java
@@ -5,7 +5,6 @@ import org.apache.commons.lang3.StringUtils;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -114,6 +113,7 @@ public class WebFragment extends Fragment implements ActionBarClient {
 	WebViewClient mWebViewClient = new WebViewClient() {
 		public boolean shouldOverrideUrlLoading(WebView view, String url) {
 			view.loadUrl(url);
+			mUrl = url;
 			return true;
 		}
 	};


### PR DESCRIPTION
Fixes Issue #40

Solution:
- Saving the state of `mWebView` and restoring it in `onCreateView` remedies the orientation change issue.
- Grabbing the current URL value into `mUrl` enables the "Open In Browser" functionality to open the browser with the current URL. This allows the user to navigate to different pages in the integrated `WebView` browser, and continue browsing in their choice of browser.
