### PR TITLE
Crashlytics issue #209 - mPage NullPointerException

### DIFF
--- a/src/com/airlocksoftware/hackernews/fragment/StoryFragment.java
+++ b/src/com/airlocksoftware/hackernews/fragment/StoryFragment.java
@@ -155,7 +155,7 @@ public class StoryFragment extends Fragment implements ActionBarClient, LoaderMa
 			mAdapter.onRestoreInstanceState(savedInstanceState);
 		}
 
-		Crashlytics.setString("StoryFragment :: mPage", mPage.toString());
+		Crashlytics.setString("StoryFragment :: mPage", mPage == null ? "" : mPage.toString());
 
 		mShouldRestoreListState = true;
 


### PR DESCRIPTION
Can cause NullPointerException when mPage is `null`

https://www.crashlytics.com/airlock-software/android/apps/com.airlocksoftware.hackernews/issues/532d616efabb27481b1869bf
