### PR TITLE
Fix saving 'Automatic bug reports' setting

### DIFF
--- a/src/com/airlocksoftware/hackernews/activity/SettingsActivity.java
+++ b/src/com/airlocksoftware/hackernews/activity/SettingsActivity.java
@@ -35,7 +35,7 @@ public class SettingsActivity extends SlideoutMenuActivity {
 		@Override
 		public void onClick(View v) {
 			mSubmitBugReports = !mSubmitBugReports;
-			mUserPrefs.saveOpenInBrowser(mSubmitBugReports);
+			mUserPrefs.saveBugsenseEnabled(mSubmitBugReports);
 			notifyDataSetChanged();
 		}
 	};


### PR DESCRIPTION
Unselecting the "Automatic bug reports" setting (which was set to true by default) would not persist since the OnClickListener was saving the result to the `OPEN_IN_BROWSER` user preference instead of `BUGSENSE_ENABLED`. This is a trivial fix.

(Thanks for building this app!)
