### PR TITLE
Fix overlapping text displayed in SearchActivity

### DIFF
--- a/src/com/airlocksoftware/hackernews/activity/SearchActivity.java
+++ b/src/com/airlocksoftware/hackernews/activity/SearchActivity.java
@@ -291,7 +291,7 @@ public class SearchActivity extends BackActivity implements LoaderManager.Loader
 		boolean loadingVis = mIsLoading && adapterEmpty;
 		boolean errorVis = mLastResult == Result.FAILURE && !mIsLoading;
 		// Result.EMPTY refers to initial run of loader, not "no results" TODO should probably make this more logical
-		boolean noResultsVis = !errorVis && adapterEmpty && mLastResult != Result.EMPTY;
+		boolean noResultsVis = !errorVis && !mIsLoading && adapterEmpty && mLastResult != Result.EMPTY;
 
 		mSearchButton.showProgress(mIsLoading);
 


### PR DESCRIPTION
Searching any text would display "No results found" and "Loading..." on top of each other, until the search results loaded. This is a minor fix, adding an additional check to make sure that the "no results" text is hidden if the search results are currently loading.
