### PR TITLE
Fix div to span change in HN's HTML for comments

### DIFF
--- a/src/com/airlocksoftware/hackernews/parser/CommentsParser.java
+++ b/src/com/airlocksoftware/hackernews/parser/CommentsParser.java
@@ -240,7 +240,7 @@ public class CommentsParser {
 	}
 
 	private static String getHtml(Element commentContainer) {
-		Elements comment = commentContainer.select("span.comment > :not(p:has(font[size]))");
+		Elements comment = commentContainer.select("div.comment > :not(p:has(font[size]))");
 		String html = comment.outerHtml();
 		// delete font tags from Html
 		html = html.replaceAll("[<](/)?font[^>]*[>]", "");


### PR DESCRIPTION
I don't have an android environment, could someone test this for me?

I reproduced the issue using js, here's the [gist](https://gist.github.com/Everlag/a091036678685089898090f32102ec24). This [spooky selector here](https://github.com/bishopmatthew/HackerNews/blob/d0b041e075885e0d8e8bd1e552d92e956b92ea22/src/com/airlocksoftware/hackernews/parser/CommentsParser.java#L243) didn't work in browser. I changed 'span.comment' to 'div.comment' and went from an empty selection to a single div. If there are further html changes down the line, I didn't get there.
